### PR TITLE
fix(UMD path): Find dom-library with require.resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "build": "kcd-scripts build",
     "lint": "kcd-scripts lint",
     "test:unit": "kcd-scripts test --no-watch --config=jest.config.js",
+    "test:unit:monorepo": "cd tests/unit && kcd-scripts test --no-watch --config=../../jest.config.js",
     "test:testcafe:serve": "serve --listen 13370 ./test-app",
     "test:testcafe:run": "testcafe --skip-js-errors",
     "validate": "kcd-scripts validate build,lint,test",
     "test:testcafe": "npm-run-all --silent --parallel --race test:testcafe:serve test:testcafe:run",
-    "test": "npm-run-all --parallel test:unit test:testcafe",
+    "test": "npm-run-all --parallel test:unit test:unit:monorepo test:testcafe",
     "semantic-release": "semantic-release"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,9 @@ import { ClientFunction, Selector } from 'testcafe'
 import { queries } from '@testing-library/dom'
 
 const DOM_TESTING_LIBRARY_UMD_PATH = path.join(
-  './node_modules',
-  '@testing-library/dom/dist/@testing-library/dom.umd.js',
+  require.resolve( '@testing-library/dom' ),
+  '../../',
+  'dist/@testing-library/dom.umd.js',
 )
 const DOM_TESTING_LIBRARY_UMD = fs.readFileSync(DOM_TESTING_LIBRARY_UMD_PATH).toString()
 


### PR DESCRIPTION
### Summary
Find the UMD path using [`require.resolve`](https://nodejs.org/api/modules.html#modules_require_resolve_request_options) instead of using a using a relative path based on the current working directory.


### Detailed explanation
This enables support for monorepo projects. Many (dev)Dependencies in eg. [Yarn Workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) are installed in the `node_modules` folder in the root of the monorepo even if they are described in a `package.json` of a single workspace. A workspace might start a TestCafé test, initiated from the workspace folder eg. `<root-of-monorepo>/packages/<workspace-folder>`. Here, the functionality of this package break because it determines the `UMD_PATH` starting from the current working directory.

I added an extra unit test `npm run test:unit:monorepo` to simulate a monorepo environment a.k.a. starting the process in another folder than where the node_modules folder is found.

The original error can be recreated by running the `npm run test:unit:monorepo` without the applied fix.

Closes #17

I'm happy to hear your feedback!