### PR TITLE
fix: minor lint error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,12 +77,12 @@ function isSelector(sel: SelectorArg): sel is Selector {
 
 const bindFunction = <
   T extends QueryName,
-  Options = Parameters<typeof queries[T]>[2]
+  MatcherOptions = Parameters<typeof queries[T]>[2]
 >(
   queryName: T
 ) => {
   const query = queryName.replace("find", "query") as T;
-  return (matcher: Matcher, options?: Options) => {
+  return (matcher: Matcher, options?: MatcherOptions) => {
     return Selector(
       () =>
         window.TestingLibraryDom[query](document.body, matcher, options) as


### PR DESCRIPTION
Fixes minro lint error:
```
/Users/chagendorn/workspace/testcafe-testing-library/src/index.ts
  80:3  error  'Options' is already declared in the upper scope  @typescript-eslint/no-shadow

✖ 1 problem (1 error, 0 warnings)
```