### PR TITLE
ci: configure main branch for publishing

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,18 @@
+{
+  "release": {
+    "branches": [
+      "+([0-9])?(.{+([0-9]),x}).x",
+      "main",
+      "next",
+      "next-major",
+      {
+        "name": "beta",
+        "prerelease": true
+      },
+      {
+        "name": "alpha",
+        "prerelease": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes a CI issue where merges on main are not deployed anymore. Sementic-release do not have `main` configured as default branch name. I override the config for default branches now to replace `master` with `main`