### PR TITLE
feat: upgrade testcafe for 2.x support (#375)

### DIFF
--- a/.github/workflows/testcafe-testing-library.yml
+++ b/.github/workflows/testcafe-testing-library.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [12, 14, 16]
+        node: [14, 16, 18]
         browser: ["chrome:headless", "firefox:headless"]
     steps:
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -22,29 +22,29 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@testing-library/dom": "^7.27.1"
+    "@testing-library/dom": "^8.19.0"
   },
   "peerDependencies": {
-    "testcafe": ">= 1.5.0"
+    "testcafe": ">=2.0.0"
   },
   "devDependencies": {
-    "eslint": "^8.13.0",
-    "eslint-config-prettier": "^8.1.0",
+    "eslint": "^8.26.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-testcafe": "^0.2.1",
-    "kcd-scripts": "^12.2.0",
+    "kcd-scripts": "^12.3.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.3.2",
-    "semantic-release": "^19.0.2",
-    "testcafe": "^1.8.4",
-    "ts-jest": "^27.0.3",
-    "typescript": "^4.0.2"
+    "prettier": "^2.7.1",
+    "semantic-release": "^19.0.5",
+    "testcafe": ">=2.0.0",
+    "ts-jest": "^29.0.3",
+    "typescript": "^4.8.4"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/testing-library/testcafe-testing-library.git"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,14 +76,9 @@ function isSelector(sel: SelectorArg): sel is Selector {
   return sel.constructor.name === SELECTOR_TYPE;
 }
 
-const bindFunction = <
-  T extends QueryName,
-  MatcherOptions = Parameters<typeof queries[T]>[2]
->(
-  queryName: T
-) => {
+const bindFunction = <T extends QueryName>(queryName: T) => {
   const query = queryName.replace("find", "query") as T;
-  return (matcher: Matcher, options?: MatcherOptions) => {
+  return (matcher: Matcher, options?: Parameters<typeof queries[T]>[2]) => {
     return Selector(
       () =>
         window.TestingLibraryDom[query](document.body, matcher, options) as

--- a/tests/testcafe/selectors.ts
+++ b/tests/testcafe/selectors.ts
@@ -71,6 +71,6 @@ test("still works after browser page load", async (t) => {
 });
 
 test("still works after reload", async (t) => {
-  await t.eval(() => location.reload(true));
+  await t.eval(() => location.reload());
   await t.expect(getByText("getByText").exists).ok();
 });


### PR DESCRIPTION
BREAKING CHANGE: Upgrades testcafe to suppor 2.x and removes node 12.x support